### PR TITLE
Python 2&3 Compatibility

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -13,6 +13,7 @@ the appropriate options to ``use_setuptools()``.
 
 This file can also be run as a script to install or upgrade setuptools.
 """
+from __future__ import print_function
 import sys
 DEFAULT_VERSION = "0.6c9"
 DEFAULT_URL     = "http://pypi.python.org/packages/%s/s/setuptools/" % sys.version[:3]
@@ -62,10 +63,10 @@ def _validate_md5(egg_name, data):
     if egg_name in md5_data:
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
-            print >>sys.stderr, (
+            print((
                 "md5 validation of %s failed!  (Possible download problem?)"
                 % egg_name
-            )
+            ), file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -95,14 +96,14 @@ def use_setuptools(
         return do_download()       
     try:
         pkg_resources.require("setuptools>="+version); return
-    except pkg_resources.VersionConflict, e:
+    except pkg_resources.VersionConflict as e:
         if was_imported:
-            print >>sys.stderr, (
+            print((
             "The required version of setuptools (>=%s) is not available, and\n"
             "can't be installed while this script is running. Please install\n"
             " a more recent version first, using 'easy_install -U setuptools'."
             "\n\n(Currently using %r)"
-            ) % (version, e.args[0])
+            ) % (version, e.args[0]), file=sys.stderr)
             sys.exit(2)
         else:
             del pkg_resources, sys.modules['pkg_resources']    # reload ok
@@ -208,10 +209,10 @@ def main(argv, version=DEFAULT_VERSION):
                 os.unlink(egg)
     else:
         if setuptools.__version__ == '0.0.1':
-            print >>sys.stderr, (
+            print((
             "You have an obsolete version of setuptools installed.  Please\n"
             "remove it from your system entirely before rerunning this script."
-            )
+            ), file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version
@@ -230,8 +231,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print "Setuptools version",version,"or greater has been installed."
-            print '(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)'
+            print("Setuptools version",version,"or greater has been installed.")
+            print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):
     """Update our built-in md5 registry"""
@@ -254,7 +255,7 @@ def update_md5(filenames):
 
     match = re.search("\nmd5_data = {\n([^}]+)}", src)
     if not match:
-        print >>sys.stderr, "Internal error!"
+        print("Internal error!", file=sys.stderr)
         sys.exit(2)
 
     src = src[:match.start(1)] + repl + src[match.end(1):]

--- a/piston/authentication.py
+++ b/piston/authentication.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import oauth
 from django.http import HttpResponse, HttpResponseRedirect
 from django.contrib.auth.models import User, AnonymousUser
@@ -75,7 +76,7 @@ def load_data_store():
 
     try:
         mod = __import__(module, {}, {}, attr)
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured, 'Error importing OAuth data store %s: "%s"' % (module, e)
 
     try:
@@ -130,7 +131,7 @@ def oauth_request_token(request):
         token = oauth_server.fetch_request_token(oauth_request)
 
         response = HttpResponse(token.to_string())
-    except oauth.OAuthError, err:
+    except oauth.OAuthError as err:
         response = send_oauth_error(err)
 
     return response
@@ -153,7 +154,7 @@ def oauth_user_auth(request):
         
     try:
         token = oauth_server.fetch_request_token(oauth_request)
-    except oauth.OAuthError, err:
+    except oauth.OAuthError as err:
         return send_oauth_error(err)
         
     try:
@@ -184,7 +185,7 @@ def oauth_user_auth(request):
                 
             response = HttpResponseRedirect(callback+args)
                 
-        except oauth.OAuthError, err:
+        except oauth.OAuthError as err:
             response = send_oauth_error(err)
     else:
         response = HttpResponse('Action not allowed.')
@@ -200,7 +201,7 @@ def oauth_access_token(request):
     try:
         token = oauth_server.fetch_access_token(oauth_request)
         return HttpResponse(token.to_string())
-    except oauth.OAuthError, err:
+    except oauth.OAuthError as err:
         return send_oauth_error(err)
 
 INVALID_PARAMS_RESPONSE = send_oauth_error(oauth.OAuthError('Invalid request parameters.'))
@@ -224,8 +225,8 @@ class OAuthAuthentication(object):
         if self.is_valid_request(request):
             try:
                 consumer, token, parameters = self.validate_token(request)
-            except oauth.OAuthError, err:
-                print send_oauth_error(err)
+            except oauth.OAuthError as err:
+                print(send_oauth_error(err))
                 return False
 
             if consumer and token:

--- a/piston/models.py
+++ b/piston/models.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import urllib
 from django.db import models
 from django.contrib.auth.models import User
@@ -104,10 +105,10 @@ class Consumer(models.Model):
                 mail_admins(subject, body, fail_silently=True)
 
             if settings.DEBUG:
-                print "Mail being sent, to=%s" % rcpt
-                print "Subject: %s" % subject
+                print("Mail being sent, to=%s" % rcpt)
+                print("Subject: %s" % subject)
 
-                print body
+                print(body)
 
     class Meta:
         app_label = 'piston'

--- a/piston/resource.py
+++ b/piston/resource.py
@@ -111,10 +111,10 @@ class Resource(object):
 
         try:
             result = meth(request, *args, **kwargs)
-        except FormValidationError, e:
+        except FormValidationError as e:
             # TODO: Use rc.BAD_REQUEST here
             return HttpResponse("Bad Request: %s" % e.form.errors, status=400)
-        except TypeError, e:
+        except TypeError as e:
             result = rc.BAD_REQUEST
             hm = HandlerMethod(meth)
             sig = hm.get_signature()
@@ -130,10 +130,10 @@ class Resource(object):
                 msg += '\n\nException was: %s' % str(e)
 
             result.content = format_error(msg)
-        except HttpStatusCode, e:
+        except HttpStatusCode as e:
             #result = e ## why is this being passed on and not just dealt with now?
             return e.response
-        except Exception, e:
+        except Exception as e:
             """
             On errors (like code errors), we'd like to be able to
             give crash reports to both admins and also the calling
@@ -176,7 +176,7 @@ class Resource(object):
             resp.streaming = self.stream
 
             return resp
-        except HttpStatusCode, e:
+        except HttpStatusCode as e:
             return e.response
 
     @staticmethod

--- a/tests/test_project/apps/testapp/tests.py
+++ b/tests/test_project/apps/testapp/tests.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 
 from django.test import TestCase
@@ -11,7 +12,7 @@ from piston.forms import OAuthAuthenticationForm
 try:
     import yaml
 except ImportError:
-    print "Can't run YAML testsuite"
+    print("Can't run YAML testsuite")
     yaml = None
 
 import urllib, base64


### PR DESCRIPTION
We ran `python-modernize --no-diffs --nobackups -f except -f numliterals
-f print -w .` to change the code to be python 2&3 compatible. We ran `python setup.py bdist_wheel` to test the changes on our local dev site and ran into no errors.